### PR TITLE
connect wallet message in button

### DIFF
--- a/components/forms/create-release.tsx
+++ b/components/forms/create-release.tsx
@@ -290,7 +290,7 @@ export default function CreateReleaseForm() {
       </div>
       <div className="pt-5">
         <div className="flex justify-end">
-          {isConnected && (
+          {isConnected ? (
             <Button
               isLoading={loadingToIPFS || isLoading}
               type="submit"
@@ -304,6 +304,15 @@ export default function CreateReleaseForm() {
               ) : (
                 "Create"
               )}
+            </Button>
+          ) : (
+            <Button
+              isLoading={loadingToIPFS || isLoading}
+              type="submit"
+              disabled={true}
+              className="bg-gray-500 text-white py-2 px-4 border rounded-md  text-sm font-medium focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 pointer-events-none"
+            >
+              Connect your wallet
             </Button>
           )}
         </div>


### PR DESCRIPTION
## Description

Here I am ensuring that a user gets to see a button with the connect your wallet message after filling out the form. Previously the button just would not render and could therefore be confusing if you are new to web 3, wallets and so on.