### PR TITLE
links all to polygon scan

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -75,9 +75,12 @@ function Card({
           <div className="px-2">
             <div className="pb-2">
               <h2 className="text-gray-700 font-bold text-sm pr-4">{name}</h2>
-              <p className="mt-1 text-sm text-blue-500">
+              <StyledLink
+                href={`${process.env.NEXT_PUBLIC_POLYGON_SCAN}/address/${token}/`}
+                className="mt-1 text-sm text-blue-500"
+              >
                 {addressSplitter(creator)}
-              </p>
+              </StyledLink>
             </div>
             <div className="border-t-2 flex justify-between border-slate-300 py-4">
               <p className="text-sm">Total Sold</p>

--- a/components/item-overview.tsx
+++ b/components/item-overview.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import React from "react";
 import Card from "components/card";
 import StyledLink from "components/styled-link";
+import { addressSplitter } from "helpers/address-splitter";
 
 interface Props {
   name: string;
@@ -35,7 +36,7 @@ export default function ItemOverview({
             <p className="w-full truncate">
               by{" "}
               <span title={creator} className="text-blue-500">
-                {creator}
+                {addressSplitter(creator)}
               </span>
             </p>
             <p className="mt-2 w-full truncate">{description}</p>


### PR DESCRIPTION
## Description

Linking the hero contract to the token address.
Splitting the address on the explore cards.

Leaving the cards for now as we have agreed a redesign in a later todo. This will affect the overall structure of the cards so I will leave linking the addresses until then.