### PR TITLE
stateful design for loading buttons

### DIFF
--- a/components/hero.tsx
+++ b/components/hero.tsx
@@ -8,6 +8,7 @@ import { BanIcon, PlayIcon, TagIcon } from "@heroicons/react/solid";
 import { useRouter } from "next/router";
 import { ethers } from "ethers";
 import { addressSplitter } from "helpers/address-splitter";
+import classNames from "classnames";
 
 function Backdrop({ image }: { image: string }) {
   return (
@@ -55,6 +56,9 @@ function Card({
       console.log("handleDeploy", error);
     }
   };
+
+  const soldOut = parseInt(maxSupply) === parseInt(totalSold);
+
   return (
     <div className="mt-16 sm:mt-24 lg:mt-0 lg:col-span-6">
       <div className="flex flex-col sm:max-w-md shadow-md rounded-lg shadow-slate-500 sm:w-full sm:mx-auto sm:overflow-hidden">
@@ -96,14 +100,24 @@ function Card({
             isLoading={minting}
             disabled={false}
             onClick={() => submitPurchase(token)}
-            className="w-full border-2 hover:shadow-md hover:transition transition bg-white rounded-md px-4 py-2 col-span-2"
+            className={classNames(
+              {
+                "cursor-not-allowed opacity-60 bg-slate-300": minting,
+              },
+              {
+                "cursor-not-allowed opacity-60 bg-slate-300 hover:shadow-none":
+                  soldOut,
+              },
+
+              "w-full border-2 hover:shadow-md hover:transition transition bg-white rounded-md px-4 py-2 col-span-2"
+            )}
           >
             {minting ? (
               <>
                 <ActivityIndicator className="h-5 w-5 inline mr-2 animate-spin text-blue-400" />
                 <span className="text-blue-400">Loading</span>
               </>
-            ) : !false ? (
+            ) : !soldOut ? (
               <>
                 <TagIcon className="h-4 inline text-blue-400 mr-2" />
                 <span className="text-blue-400">Mint</span>
@@ -111,7 +125,9 @@ function Card({
             ) : (
               <>
                 <BanIcon className="h-4 inline text-red-400 mr-2" />
-                <span className="text-red-400">Sold Out</span>
+                <span className="text-red-400 opacity-60 bg-slate-300">
+                  Sold Out
+                </span>
               </>
             )}
           </Button>

--- a/components/purchase.tsx
+++ b/components/purchase.tsx
@@ -5,6 +5,7 @@ import {
   ShareIcon,
   TagIcon,
 } from "@heroicons/react/solid";
+import classNames from "classnames";
 import ActivityIndicator from "components/activity-indicator";
 import Button from "components/button";
 import EthLogo from "components/logo/eth-logo";
@@ -163,25 +164,32 @@ export default function Puchase({
             isLoading={minting}
             disabled={soldOut}
             onClick={() => submitPurchase(tokenId)}
-            className="w-full border-2 hover:shadow-md hover:transition transition bg-white rounded-md px-4 py-2 col-span-2"
+            className={classNames(
+              {
+                "cursor-not-allowed opacity-60 bg-slate-300": minting,
+              },
+              {
+                "cursor-not-allowed opacity-60 bg-slate-300 hover:shadow-none":
+                  soldOut,
+              },
+
+              "w-full border-2 hover:shadow-md hover:transition transition bg-white rounded-md px-4 py-2 col-span-2"
+            )}
           >
             {minting ? (
-              // diplsay loading state whilst minting
               <>
                 <ActivityIndicator className="h-5 w-5 inline mr-2 animate-spin text-blue-400" />
                 <span className="text-blue-400">Loading</span>
               </>
             ) : !soldOut ? (
-              //If not loading and you are able to mint then show mint
               <>
                 <TagIcon className="h-4 inline text-blue-400 mr-2" />
                 <span className="text-blue-400">Mint</span>
               </>
             ) : (
-              //If sold out then show to the user that all nfts are sold
               <>
                 <BanIcon className="h-4 inline text-red-400 mr-2" />
-                <span className="text-red-400">Sold Out</span>
+                <span className="text-red-400 ">Sold Out</span>
               </>
             )}
           </Button>


### PR DESCRIPTION
## Description

This PR fixes the loading state design of the buttons when minting and when sold out, they now look a lot less active.

### Images

![Screenshot 2022-07-15 at 13 23 21](https://user-images.githubusercontent.com/68110533/179222715-f98af267-4b40-4ca9-8d5b-51a4f869c96f.png)
![Screenshot 2022-07-15 at 13 23 37](https://user-images.githubusercontent.com/68110533/179222719-8c1970c2-3b3a-4b70-9f9b-2b668b7788d9.png)
![Screenshot 2022-07-15 at 13 24 37](https://user-images.githubusercontent.com/68110533/179222723-fadfecad-1278-4cb8-845b-3433b772b8cc.png)
![Screenshot 2022-07-15 at 13 24 51](https://user-images.githubusercontent.com/68110533/179222725-2905a026-1650-47be-90bb-8fa499483b73.png)
