### PR TITLE
Order of transactions

### DIFF
--- a/pages/explore/[id].tsx
+++ b/pages/explore/[id].tsx
@@ -56,7 +56,11 @@ export default function Release({ tokenId }: Props) {
 
   const getTransactionHistory = gql`
     query ($tokenId: String!) {
-      transactions(where: { token: $tokenId }) {
+      transactions(
+        where: { token: $tokenId }
+        orderBy: timestamp
+        orderDirection: desc
+      ) {
         id
         from
         to


### PR DESCRIPTION
## Description

This PR ensures that the transactions in the table are ordered by created. So as a user when I mint I now see my transaction as the latest one ordered by date. 

### Images

![Screenshot 2022-07-21 at 15 50 30](https://user-images.githubusercontent.com/68110533/180244344-534bbaa3-f345-4c68-8513-2bfba01a5e81.png)
