### PR TITLE
Adding image priority

### DIFF
--- a/components/item-overview.tsx
+++ b/components/item-overview.tsx
@@ -37,6 +37,7 @@ function ItemOverview({ name, creator, image, tokenId, action }: Props) {
           <div className="relative aspect-w-1 aspect-h-1">
             <StyledLink href={`/explore/${tokenId}`} className="cursor-pointer">
               <Image
+                priority={true}
                 blurDataURL="/images/placeholder.png"
                 placeholder="blur"
                 layout="fill"


### PR DESCRIPTION
## Description

according to the docs this should prevent lazy loading, hopefully this fixes the issue of the explore item links not loading immediately.
